### PR TITLE
Fix invalid literal for int() with base 10.

### DIFF
--- a/tools/mkuserimg_mke2fs.py
+++ b/tools/mkuserimg_mke2fs.py
@@ -135,7 +135,7 @@ def ConstructE2fsCommands(args):
     e2fsdroid_opts += ["-S", args.file_contexts]
   if args.flash_erase_block_size:
     mke2fs_extended_opts.append("stripe_width={}".format(
-        int(args.flash_erase_block_size) / BLOCKSIZE))
+        int(float(args.flash_erase_block_size)) / BLOCKSIZE))
   if args.flash_logical_block_size:
     # stride should be the max of 8kb and the logical block size
     stride = max(int(args.flash_logical_block_size), 8192)


### PR DESCRIPTION
This was made to prevent errors when the calculated image size is big.